### PR TITLE
fix type of data object

### DIFF
--- a/src/parseJEOL.js
+++ b/src/parseJEOL.js
@@ -174,7 +174,7 @@ export default function parseJEOL(buffer) {
     ioBuffer.setLittleEndian();
   }
 
-  let data = [];
+  let data = {};
   let dataSectionCount = 1;
   let realComplex = 0;
   for (let type of header.dataAxisType) {


### PR DESCRIPTION
The type of data was wrong. In the case the user wanted to do a JSON.stringify of the parseJEOL return object, it would consider it as a list and not export its attributes.